### PR TITLE
fix fan keyerror and naming for humble branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 [NVIDIA Developer Blog](https://developer.nvidia.com/blog/implementing-robotics-applications-with-ros-2-and-ai-on-jetson-platform-2/)
 
 ## ROS2 wrapper for Jetson Stats (jtop)
-This repository takes inspiration from [ROS-jtop](https://github.com/rbonghi/ros_jetson_stats) and creates package for ros2 (currently tested on eloquent)
+This repository takes inspiration from [ROS-jtop](https://github.com/rbonghi/ros_jetson_stats) and creates package for ros2
 
 ## Pre-requisite
-ROS2 Eloquent [Install Guide](https://index.ros.org/doc/ros2/Installation/Eloquent/Linux-Development-Setup/)
+ROS2 Humble [Install Guide](https://docs.ros.org/en/humble/Installation.html)
 
 ## Set up
 1. Install Jetson Stats: <br/>
@@ -14,7 +14,7 @@ ROS2 Eloquent [Install Guide](https://index.ros.org/doc/ros2/Installation/Eloque
 ``` cd dev_ws/src``` <br/>
 ``` git clone https://github.com/NVIDIA-AI-IOT/ros2_jetson_stats.git``` <br/>
 3. Build
-``` sudo rosdep install --from-paths ros2_jtop --ignore-src --rosdistro eloquent -y ``` <br/>
+``` sudo rosdep install --from-paths ros2_jtop --ignore-src --rosdistro humble -y ``` <br/>
 ``` colcon build ``` <br/>
 ``` . install/setup.bash ```<br/>
 

--- a/ros2_jetson_stats/ros2_jetson_stats/utils.py
+++ b/ros2_jetson_stats/ros2_jetson_stats/utils.py
@@ -240,7 +240,7 @@ def fan_status(hardware, name, fan):
         values=[
             KeyValue(key='Mode', value=str(fan['profile'])),
             KeyValue(key="Speed", value=str(fan['speed'])),
-            KeyValue(key="Control", value=str(fan['control'])),
+            KeyValue(key="Control", value=str(fan['rpm'])),
         ])
     return d_fan
 


### PR DESCRIPTION
I tested with 4.2.3 and 4.2.8 and they both had the "control" key error and when I printed the values of the fan dictionary, it only had "profile, speed, rpm" as keys.

also since this is the humble branch, I fixed some names and links