### PR TITLE
Publish fan RPM and update README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,47 @@
+#Build artifacts
+*.build
+build
+install
+log
+__pycache__
+
+# Python byte code
+*.pyc
+
+# Clion
+.idea
+
+# Eclipse
+.cproject
+.project
+.settings/
+
+# Qt Creator generated files
+*.pro.user*
+*.user
+
+# Vim temporary files
+.*.swp
+
+# Visual Studio Code
+.vscode/*
+!.vscode/tasks.json
+.history
+
+# Visual Studio generated files
+*.ib_pdb_index
+*.idb
+*.ilk
+*.pdb
+*.sln
+*.suo
+*.vcproj
+*vcproj.*.*.user
+*.ncb
+*.sdf
+*.opensdf
+*.vcxproj
+*vcxproj.*
+
+# XEmacs temporary files
+*.flc

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 [NVIDIA Developer Blog](https://developer.nvidia.com/blog/implementing-robotics-applications-with-ros-2-and-ai-on-jetson-platform-2/)
 
 ## ROS2 wrapper for Jetson Stats (jtop)
-This repository takes inspiration from [ROS-jtop](https://github.com/rbonghi/ros_jetson_stats) and creates package for ros2 (currently tested on eloquent)
+This repository takes inspiration from [ROS-jtop](https://github.com/rbonghi/ros_jetson_stats) and creates package for ROS2
 
 ## Pre-requisite
-ROS2 Eloquent [Install Guide](https://index.ros.org/doc/ros2/Installation/Eloquent/Linux-Development-Setup/)
+ROS2 Humble [Install Guide](https://docs.ros.org/en/humble/Installation.html)
 
 ## Set up
 1. Install Jetson Stats: <br/>
@@ -14,7 +14,7 @@ ROS2 Eloquent [Install Guide](https://index.ros.org/doc/ros2/Installation/Eloque
 ``` cd dev_ws/src``` <br/>
 ``` git clone https://github.com/NVIDIA-AI-IOT/ros2_jetson_stats.git``` <br/>
 3. Build
-``` sudo rosdep install --from-paths ros2_jtop --ignore-src --rosdistro eloquent -y ``` <br/>
+``` sudo rosdep install --from-paths ros2_jtop --ignore-src --rosdistro humble -y ``` <br/>
 ``` colcon build ``` <br/>
 ``` . install/setup.bash ```<br/>
 

--- a/ros2_jetson_stats/ros2_jetson_stats/utils.py
+++ b/ros2_jetson_stats/ros2_jetson_stats/utils.py
@@ -240,7 +240,7 @@ def fan_status(hardware, name, fan):
         values=[
             KeyValue(key='Mode', value=str(fan['profile'])),
             KeyValue(key="Speed", value=str(fan['speed'])),
-            KeyValue(key="Control", value=str(fan['control'])),
+            KeyValue(key="RPM", value=str(fan['rpm'])),
         ])
     return d_fan
 


### PR DESCRIPTION
- Publish fan RPM instead of controller type. This is is makes the code compatible with older Jetpack version.
- Update README to reference `humble` instead of `eloquent`

This is basically the same as https://github.com/NVIDIA-AI-IOT/ros2_jetson_stats/pull/9, which got deleted by its author two days back...